### PR TITLE
Added a return statement to avoid a compilation error.

### DIFF
--- a/secp256.go
+++ b/secp256.go
@@ -268,4 +268,5 @@ func RecoverPubkey(msg []byte, sig []byte) ([]byte, error) {
 	} else {
 		return pubkey, nil
 	}
+	return nil, errors.New("Impossible Error: func RecoverPubkey has reached an unreachable state")
 }


### PR DESCRIPTION
It should be unreachable, but now the code compiles.

I'm new to Go so forgive me if this is the wrong solution, but it did make the compilation error go away. 

secp256.go:243[/tmp/go-build468925377/github.com/obscuren/secp256k1-go/_obj/secp256.cgo1.go:208]: function ends without a return statement
